### PR TITLE
update python versions badge

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -8,12 +8,12 @@ header:
   cta_label2: "<i class='fas fa-envelope'></i> Get Updates"
   cta_url: "/start/#install"
   cta_url2: "/contact/#list"
-  subtitle: <a href='https://pypi.python.org/pypi/pandapower'> <img src='{{"/images/home/shield_python_versions.svg" | relative_url}}'></a>
+  subtitle: <a href='https://pypi.python.org/pypi/pandapower'> <img src='{{"https://img.shields.io/pypi/pyversions/pandapower.svg"}}'></a>
   
 shields:
   - icon: 'https://badge.fury.io/py/pandapower.svg'
     url: https://pypi.python.org/pypi/pandapower
-  - icon: 'images/home/shield_python_versions.svg'
+  - icon: 'https://img.shields.io/pypi/pyversions/pandapower.svg'
     url: https://pypi.python.org/pypi/pandapower
   - icon: https://readthedocs.org/projects/pandapower/badge/
     url: http://pandapower.readthedocs.io/


### PR DESCRIPTION
linked the address https://img.shields.io/pypi/pyversions/pandapower.svg instead of a local file